### PR TITLE
Change MessageAndError member visibility to public

### DIFF
--- a/src/RdKafka/Message.cs
+++ b/src/RdKafka/Message.cs
@@ -19,7 +19,7 @@ namespace RdKafka
 
     public struct MessageAndError
     {
-        internal Message Message;
-        internal ErrorCode Error;
+        public Message Message;
+        public ErrorCode Error;
     }
 }


### PR DESCRIPTION
Make MessageAndError members public so that we can build consumers that are not event-driven.