### PR TITLE
Negative delivery report does not trigger an unhandled exception

### DIFF
--- a/src/RdKafka/Producer.cs
+++ b/src/RdKafka/Producer.cs
@@ -48,6 +48,7 @@ namespace RdKafka
                     RdKafkaException.FromErr(
                         rkmessage.err,
                         Marshal.PtrToStringAnsi(rkmessage.payload)));
+                return;
             }
 
             deliveryCompletionSource.SetResult(new DeliveryReport() {


### PR DESCRIPTION
Fixes #17 

The exception is caused by incorrect completion of the deliveryCompletionSource, i.e. by calling .SetException() and then .SetResult().