### PR TITLE
Fix Issue #62

### DIFF
--- a/src/RdKafka/Topic.cs
+++ b/src/RdKafka/Topic.cs
@@ -60,11 +60,14 @@ namespace RdKafka
         {
             // Passes the TaskCompletionSource to the delivery report callback
             // via the msg_opaque pointer
+            // try only 3 times
+            int maxTryTime = 3;
             var deliveryCompletionSource = new TaskCompletionSource<DeliveryReport>();
             var gch = GCHandle.Alloc(deliveryCompletionSource);
 
-            while (true)
+            while (maxTryTime > 0)
             {
+                maxTryTime --;
                 if (handle.Produce(payload, key, partition, GCHandle.ToIntPtr(gch)) == 0)
                 {
                     // Successfully enqueued produce request


### PR DESCRIPTION
When librdkafka trying to connect an non-existing brokers, it will set buf to 0. 
And once it trying to produce data, it detect it as NOBUF, then return _QUEUE_FULL as error, then in Topic.produce method, it will treat it as buffer is temporary full, so it will wait 50 ms and try again until succeed.

To avoid it , either check buffer size or change the while loop with a maximum try number. So I set 3 as Maximum try time here to avoid infinite try.