### PR TITLE
feat: make public methods more generic

### DIFF
--- a/src/RdKafka/Consumer.cs
+++ b/src/RdKafka/Consumer.cs
@@ -54,7 +54,7 @@ namespace RdKafka
         /// partition.assignment.strategy to assign the subscription sets's
         /// topics's partitions to the consumers, depending on their subscription.
         /// </summary>
-        public void Subscribe(List<string> topics)
+        public void Subscribe(ICollection<string> topics)
         {
             handle.Subscribe(topics);
         }
@@ -73,7 +73,7 @@ namespace RdKafka
         /// The assignment set is the set of partitions actually being consumed
         /// by the KafkaConsumer.
         /// </summary>
-        public void Assign(List<TopicPartitionOffset> partitions)
+        public void Assign(ICollection<TopicPartitionOffset> partitions)
         {
             handle.Assign(partitions);
         }
@@ -124,7 +124,7 @@ namespace RdKafka
         /// <summary>
         /// Commit explicit list of offsets.
         /// </summary>
-        public Task Commit(List<TopicPartitionOffset> offsets)
+        public Task Commit(ICollection<TopicPartitionOffset> offsets)
         {
             handle.Commit(offsets);
             return Task.FromResult(false);
@@ -133,7 +133,7 @@ namespace RdKafka
         /// <summary>
         /// Retrieve committed offsets for topics+partitions.
         /// </summary>
-        public Task<List<TopicPartitionOffset>> Committed(List<TopicPartition> partitions, TimeSpan timeout)
+        public Task<List<TopicPartitionOffset>> Committed(ICollection<TopicPartition> partitions, TimeSpan timeout)
         {
             var result = handle.Committed(partitions, (IntPtr) timeout.TotalMilliseconds);
             return Task.FromResult(result);
@@ -146,7 +146,7 @@ namespace RdKafka
         /// of the last consumed message + 1, or RD_KAFKA_OFFSET_INVALID in case there was
         /// no previous message.
         /// </summary>
-        public List<TopicPartitionOffset> Position(List<TopicPartition> partitions) => handle.Position(partitions);
+        public List<TopicPartitionOffset> Position(ICollection<TopicPartition> partitions) => handle.Position(partitions);
 
         /// <summary>
         /// Get last known low (oldest/beginning) and high (newest/end) offsets for partition.

--- a/src/RdKafka/Internal/SafeKafkaHandle.cs
+++ b/src/RdKafka/Internal/SafeKafkaHandle.cs
@@ -231,7 +231,7 @@ namespace RdKafka.Internal
         }
 
         // Consumer API
-        internal void Subscribe(IList<string> topics)
+        internal void Subscribe(ICollection<string> topics)
         {
             IntPtr list = LibRdKafka.topic_partition_list_new((IntPtr) topics.Count);
             if (list == IntPtr.Zero)
@@ -336,7 +336,7 @@ namespace RdKafka.Internal
             return GetTopicList(listPtr);
         }
 
-        internal void Assign(List<TopicPartitionOffset> partitions)
+        internal void Assign(ICollection<TopicPartitionOffset> partitions)
         {
             IntPtr list = IntPtr.Zero;
             if (partitions != null)
@@ -375,7 +375,7 @@ namespace RdKafka.Internal
             }
         }
 
-        internal void Commit(List<TopicPartitionOffset> offsets)
+        internal void Commit(ICollection<TopicPartitionOffset> offsets)
         {
             IntPtr list = LibRdKafka.topic_partition_list_new((IntPtr) offsets.Count);
             if (list == IntPtr.Zero)
@@ -397,7 +397,7 @@ namespace RdKafka.Internal
             }
         }
 
-        internal List<TopicPartitionOffset> Committed(List<TopicPartition> partitions, IntPtr timeout_ms)
+        internal List<TopicPartitionOffset> Committed(ICollection<TopicPartition> partitions, IntPtr timeout_ms)
         {
             IntPtr list = LibRdKafka.topic_partition_list_new((IntPtr) partitions.Count);
             if (list == IntPtr.Zero)
@@ -418,7 +418,7 @@ namespace RdKafka.Internal
             return result;
         }
 
-        internal List<TopicPartitionOffset> Position(List<TopicPartition> partitions)
+        internal List<TopicPartitionOffset> Position(ICollection<TopicPartition> partitions)
         {
             IntPtr list = LibRdKafka.topic_partition_list_new((IntPtr) partitions.Count);
             if (list == IntPtr.Zero)


### PR DESCRIPTION
This PR came out of my desire to use a `ReadOnlyCollection` to store the topics passed into the `Subscribe` method. While making that change it made sense to change other public methods to be consistent.

This shouldn't change any functionality or break any existing applications using this lib; just provides a little more flexibility in the API.