### PR TITLE
Keep reference to PartitionerCallback after topic has been GC

### DIFF
--- a/src/RdKafka/project.json
+++ b/src/RdKafka/project.json
@@ -7,18 +7,19 @@
         "tags": ["kafka", "rdkafka"]
     },
 
-    "dependencies": {
-        "RdKafka.Internal.librdkafka": "0.9.2-ci-28"
-    },
+  "dependencies": {
+    "RdKafka.Internal.librdkafka": "0.9.2-ci-28"
+  },
 
     "frameworks": {
         "net451": { },
         "netstandard1.3": {
-            "dependencies": {
-                "System.Console": "4.0.0",
-                "System.Linq": "4.1.0",
-                "System.Runtime.InteropServices": "4.1.0"
-            }
+          "dependencies": {
+            "System.Collections.Concurrent": "4.3.0",
+            "System.Console": "4.3.0",
+            "System.Linq": "4.3.0",
+            "System.Runtime.InteropServices": "4.3.0"
+          }
         }
     }
 }


### PR DESCRIPTION
In certain case, we call partitioner callback after topic has been disposed / GCollected, and this produce a CallbackOnCollectedDelegate
I'm not really happy with this workaround as we should be able to detect when releasing the delegate reference is safe. Not sure blocking collection is useful but never know when people could use thread for whatever reason, so I ended up with this. Feel free to propose change

This is the code I used to generate the exception and validate the fix. 
This exception, given by microsoft, is random, may or may not occur during runtime and may depend of hardware, so this may not be reproductible everywhere

```
var topicConfig = new TopicConfig
{
    CustomPartitioner = (top, key, cnt) => 0
};
            
using (var kafkaProducer = new Producer("zk:9092"))
{
    for (int j = 0; j< 100; j++)
    {
        //This is to create lot of topic to help generate the error
        using (Topic topic = kafkaProducer.Topic("testPartitioner", topicConfig))
        {
            for (int i = 0; i < 10000; i++)
            {
                topic.Produce(null);
            }
        }
    }
}
```

Also updated referenced version, if you want to keep with old one feel free to tell