### PR TITLE
Ignore NO_OFFSET condition while commiting

### DIFF
--- a/src/RdKafka/Consumer.cs
+++ b/src/RdKafka/Consumer.cs
@@ -101,6 +101,8 @@ namespace RdKafka
 
         /// <summary>
         /// Commit offsets for the current assignment.
+        /// If no partitions had valid offsets to commit this will throw
+        /// RdKafkaException with ErrorCode _NO_OFFSET which is not to be considered an error
         /// </summary>
         public Task Commit()
         {

--- a/src/RdKafka/Internal/SafeKafkaHandle.cs
+++ b/src/RdKafka/Internal/SafeKafkaHandle.cs
@@ -369,7 +369,7 @@ namespace RdKafka.Internal
         internal void Commit()
         {
             ErrorCode err = LibRdKafka.commit(handle, IntPtr.Zero, false);
-            if (err != ErrorCode.NO_ERROR && err != ErrorCode._NO_OFFSET)
+            if (err != ErrorCode.NO_ERROR)
             {
                 throw RdKafkaException.FromErr(err, "Failed to commit offsets");
             }


### PR DESCRIPTION
While committing, we should ignore the NO_OFFSET error code.
There is a note in the comments in the rdkafka.h file as follows, which corroborates this change:
 If no partitions had valid offsets to commit this callback will be called
 with \p err == RD_KAFKA_RESP_ERR__NO_OFFSET which is **not** to be considered
 an error.